### PR TITLE
Force standard 28 bytes empty BGZF GZIP block for no compression BAM

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -627,8 +627,8 @@ int bgzf_close(BGZF* fp)
     if (fp->open_mode == 'w') {
         if (bgzf_flush(fp) != 0) return -1;
 		{ // add an empty block
-			// add 28 byes EOF empty block
-			fp->compress_level=0; //don't need original value again
+			// add 28 bytes EOF empty block
+			fp->compress_level=-1; //don't need original value again
 			// (different compression levels would give different empty blocks)
 			int count, block_length = deflate_block(fp, 0);
 #ifdef _USE_KNETFILE

--- a/bgzf.c
+++ b/bgzf.c
@@ -628,7 +628,7 @@ int bgzf_close(BGZF* fp)
         if (bgzf_flush(fp) != 0) return -1;
 		{ // add an empty block
 			// add 28 bytes EOF empty block
-			fp->compress_level=-1; //don't need original value again
+			fp->compress_level=Z_DEFAULT_COMPRESSION; //don't need value again
 			// (different compression levels would give different empty blocks)
 			int count, block_length = deflate_block(fp, 0);
 #ifdef _USE_KNETFILE

--- a/bgzf.c
+++ b/bgzf.c
@@ -626,24 +626,17 @@ int bgzf_close(BGZF* fp)
 {
     if (fp->open_mode == 'w') {
         if (bgzf_flush(fp) != 0) return -1;
-        if (fp->compress_level==0) {
-		// add 28 byes EOF empty block even if no compression
-		// (gzip no compresison would give block size 32 bytes)
-	        //fprintf(stderr, "[bgzf_close] Forcing empty EOF block\n");
-		int count;
-#ifdef _USE_KNETFILE
-		count = fwrite("\037\213\010\4\0\0\0\0\0\377\6\0\102\103\2\0\033\0\3\0\0\0\0\0\0\0\0\0", 1, 28, fp->x.fpw);
-#else
-		count = fwrite("\037\213\010\4\0\0\0\0\0\377\6\0\102\103\2\0\033\0\3\0\0\0\0\0\0\0\0\0", 1, 28, fp->file);
-#endif
-	} else { // add an empty block
+		{ // add an empty block
+			// add 28 byes EOF empty block
+			fp->compress_level=0; //don't need original value again
+			// (different compression levels would give different empty blocks)
 			int count, block_length = deflate_block(fp, 0);
 #ifdef _USE_KNETFILE
 			count = fwrite(fp->compressed_block, 1, block_length, fp->x.fpw);
 #else
 			count = fwrite(fp->compressed_block, 1, block_length, fp->file);
 #endif
-	}
+		}
 #ifdef _USE_KNETFILE
         if (fflush(fp->x.fpw) != 0) {
 #else


### PR DESCRIPTION
This avoids the following warning from uncompressed BAM files which don't end with the expected 28 byte empty BGZF block as an EOF marker:

[bam_header_read] EOF marker is absent. The input is probably truncated.

See mailing list discussion.

Thanks,

Peter
